### PR TITLE
Refactor app config

### DIFF
--- a/warehouse-management-service/cmd/wms/main.go
+++ b/warehouse-management-service/cmd/wms/main.go
@@ -61,8 +61,8 @@ func main() {
 
 	h := handler.New(logger, warehouseService, shelfBlockService, shelfService)
 
-	exit := make(chan os.Signal, 1)
-	signal.Notify(exit, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+	exitChan := make(chan os.Signal, 1)
+	signal.Notify(exitChan, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 
 	var wg sync.WaitGroup
 
@@ -82,7 +82,7 @@ func main() {
 	logger.Log(log.Info, "Server listening on port 80")
 
 	// listen for exit signals
-	<-exit
+	<-exitChan
 
 	// shutdown server gracefully
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/warehouse-management-service/cmd/wms/main.go
+++ b/warehouse-management-service/cmd/wms/main.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net/http"
 	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
 	"warehouse-management-service/internal/config"
 	"warehouse-management-service/internal/handler"
 	"warehouse-management-service/pkg/database/postgres"
@@ -28,24 +33,26 @@ func main() {
 
 	db, err := pg.Open()
 	if err != nil {
-		logger.Log(log.Fatal, fmt.Sprintf("App startup error: %v", err))
-		os.Exit(1)
+		logger.Log(log.Fatal, fmt.Sprintf("Failed to connect to database: %v", err))
+		return
 	}
 
-	if runDBMigrations {
-		err := pg.RunMigration(appConfig.DBMigrationSourcePath)
-		if err != nil {
-			logger.Log(log.Fatal, fmt.Sprintf("App startup error: %v", err))
-			os.Exit(1)
-		}
-	}
-
+	// close db gracefully
 	defer func() {
 		err = db.Close()
 		if err != nil {
 			logger.Log(log.Error, err)
 		}
 	}()
+
+	if runDBMigrations {
+		logger.Log(log.Info, "Running database migrations")
+		err := pg.RunMigration(appConfig.DBMigrationSourcePath)
+		if err != nil {
+			logger.Log(log.Fatal, fmt.Sprintf("Failed to run database migrations: %v", err))
+			return
+		}
+	}
 
 	// Instantiate Postgres-backed services
 	warehouseService := postgres.NewWarehouseService(db)
@@ -54,12 +61,36 @@ func main() {
 
 	h := handler.New(logger, warehouseService, shelfBlockService, shelfService)
 
-	err = http.ListenAndServe(":80", h)
-	switch err {
-	case http.ErrServerClosed:
-		logger.Log(log.Info, "server shut down successfully")
-	default:
-		logger.Log(log.Error, fmt.Sprintf("error starting up server: %v", err))
-		os.Exit(1)
+	exit := make(chan os.Signal, 1)
+	signal.Notify(exit, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+
+	var wg sync.WaitGroup
+
+	server := &http.Server{Addr: ":80", Handler: h}
+	go func() {
+		wg.Add(1)
+		defer wg.Done()
+
+		if err := server.ListenAndServe(); err != nil {
+			if err == http.ErrServerClosed {
+				logger.Log(log.Info, "server shut down successfully")
+			} else {
+				logger.Log(log.Error, fmt.Sprintf("error starting up server: %v", err))
+			}
+		}
+	}()
+	logger.Log(log.Info, "Server listening on port 80")
+
+	// listen for exit signals
+	<-exit
+
+	// shutdown server gracefully
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := server.Shutdown(ctx); err != nil {
+		logger.Log(log.Error, fmt.Sprintf("Failed to shutdown the server %v", err))
 	}
+
+	// wait for server shutdown
+	wg.Wait()
 }

--- a/warehouse-management-service/cmd/wms/main.go
+++ b/warehouse-management-service/cmd/wms/main.go
@@ -13,21 +13,12 @@ import (
 	_ "github.com/lib/pq"
 )
 
-const (
-	EnvConfigFilePath = "CONFIG_FILE_PATH"
-)
-
 func main() {
 	runDBMigrations := *flag.Bool("migrate", false, "true or false, specifies if database migrations should be run")
 
-	configFilePath, ok := os.LookupEnv(EnvConfigFilePath)
-	if !ok {
-		panic("Failed to read environment variable")
-	}
-
-	appConfig, err := config.FromFile(configFilePath)
+	appConfig, err := config.FromEnv()
 	if err != nil {
-		panic("Failed to read appConfig file")
+		panic(fmt.Sprintf("Failed to read config %v", err))
 	}
 
 	logger := log.New()
@@ -42,7 +33,7 @@ func main() {
 	}
 
 	if runDBMigrations {
-		err := pg.RunMigration(appConfig.DBMigration.SourcePath)
+		err := pg.RunMigration(appConfig.DBMigrationSourcePath)
 		if err != nil {
 			logger.Log(log.Fatal, fmt.Sprintf("App startup error: %v", err))
 			os.Exit(1)

--- a/warehouse-management-service/internal/config/config.go
+++ b/warehouse-management-service/internal/config/config.go
@@ -6,15 +6,26 @@ import (
 	"os"
 )
 
-var environmentVariables = map[string]string{
-	"dbHost":                "DB_HOST",
-	"dbPort":                "DB_PORT",
-	"dbUsername":            "DB_USERNAME",
-	"dbPassword":            "DB_PASSWORD",
-	"dbName":                "DB_NAME",
-	"dbSSLMode":             "DB_SSL_MODE",
-	"logLevel":              "LOG_LEVEL",
-	"dbMigrationSourcePath": "DB_MIGRATION_SOURCE_PATH",
+const (
+	EnvKeyDBHost                = "DB_HOST"
+	EnvKeyDBPort                = "DB_PORT"
+	EnvKeyDBUsername            = "DB_USERNAME"
+	EnvKeyDBPassword            = "DB_PASSWORD"
+	EnvKeyDBName                = "DB_NAME"
+	EnvKeyDBSSlMode             = "DB_SSL_MODE"
+	EnvKeyLogLevel              = "LOG_LEVEL"
+	EnvKeyDBMigrationSourcePath = "DB_MIGRATION_SOURCE_PATH"
+)
+
+var environmentVariables = map[string]struct{}{
+	EnvKeyDBHost:                struct{}{},
+	EnvKeyDBPort:                struct{}{},
+	EnvKeyDBUsername:            struct{}{},
+	EnvKeyDBPassword:            struct{}{},
+	EnvKeyDBName:                struct{}{},
+	EnvKeyDBSSlMode:             struct{}{},
+	EnvKeyLogLevel:              struct{}{},
+	EnvKeyDBMigrationSourcePath: struct{}{},
 }
 
 type PostgresConfig struct {
@@ -49,24 +60,24 @@ func FromFile(path string) (*Config, error) {
 
 func FromEnv() (*Config, error) {
 	config := make(map[string]string)
-	for identifier, envVar := range environmentVariables {
-		value, ok := os.LookupEnv(envVar)
+	for envKey, _ := range environmentVariables {
+		value, ok := os.LookupEnv(envKey)
 		if !ok {
-			return nil, fmt.Errorf("unable to read environment variable: %s", envVar)
+			return nil, fmt.Errorf("unable to read environment variable: %s", envKey)
 		}
-		config[identifier] = value
+		config[envKey] = value
 	}
 	return &Config{
 			Postgres: PostgresConfig{
-				Host:     config["dbHost"],
-				Port:     config["dbPort"],
-				Username: config["dbUsername"],
-				Password: config["dbPassword"],
-				DBName:   config["dbName"],
-				SSLMode:  config["dbSSLMode"],
+				Host:     config[EnvKeyDBHost],
+				Port:     config[EnvKeyDBPort],
+				Username: config[EnvKeyDBUsername],
+				Password: config[EnvKeyDBPassword],
+				DBName:   config[EnvKeyDBName],
+				SSLMode:  config[EnvKeyDBSSlMode],
 			},
-			LogLevel:              config["logLevel"],
-			DBMigrationSourcePath: config["dbMigrationSourcePath"],
+			LogLevel:              config[EnvKeyLogLevel],
+			DBMigrationSourcePath: config[EnvKeyDBMigrationSourcePath],
 		},
 		nil
 }

--- a/warehouse-management-service/internal/config/config_test.go
+++ b/warehouse-management-service/internal/config/config_test.go
@@ -17,7 +17,7 @@ func TestFromFile(t *testing.T) {
 			DBName:   "db",
 			SSLMode:  "disable",
 		},
-		DBMigration: DBMigration{SourcePath: "file://warehouse-management-service/db/migrations"},
+		DBMigrationSourcePath: "file://warehouse-management-service/db/migrations",
 	}
 
 	if err != nil || !reflect.DeepEqual(config, wantConfig) {

--- a/warehouse-management-service/pkg/database/postgres/init_test.go
+++ b/warehouse-management-service/pkg/database/postgres/init_test.go
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 	}
 	defer db.Close()
 
-	err = postgres.RunMigration(cfg.DBMigration.SourcePath)
+	err = postgres.RunMigration(cfg.DBMigrationSourcePath)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to run database migrations: %v", err))
 	}
@@ -57,7 +57,7 @@ func TestMain(m *testing.M) {
 
 	m.Run()
 
-	err = postgres.MigrateDown(cfg.DBMigration.SourcePath)
+	err = postgres.MigrateDown(cfg.DBMigrationSourcePath)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to migrate down: %v", err))
 	}


### PR DESCRIPTION
- Refactor app config to read values from environment variables instead of config files
  This has been done to avoid checking in `.json` config files (which contain secrets) to source control. Since the number of fields in the config is relatively small, env variables are being used for the purpose.

- Listen to OS signals and add graceful shutdown